### PR TITLE
Changing X-Frame-Options from DENY to SAMEORIGIN

### DIFF
--- a/nginx/staticland
+++ b/nginx/staticland
@@ -42,7 +42,7 @@ server {
   ssl_dhparam /etc/ssl/certs/dhparam.pem;
 
   add_header Strict-Transport-Security "max-age=15768000" always;
-  add_header X-Frame-Options DENY;
+  add_header X-Frame-Options SAMEORIGIN;
   add_header X-Content-Type-Options nosniff;
 
   location / {


### PR DESCRIPTION
This change will remove an unnecessary security restriction - pages should be allowed to be loaded into iFrames within the same origin. DENY is very restrictive.