### PR TITLE
Update installation instructions to mention env var setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ sudo service nginx restart
 npm i -g forever
 ```
 
+#### set the STATICLAND_SECRET environment variable
+
+```
+export STATICLAND_SECRET=SomethingMoreSecretThanThis
+```
+
 #### start the staticland server
 
 ```


### PR DESCRIPTION
Registration requests will fail unless the STATICLAND_SECRET
environment variable is set before starting the server.